### PR TITLE
Adding function to get any primitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Critical items to know are:
 Versions here coincide with releases on pypi.
 
 ## [master](https://github.com/vsoch/nushell-plugin-python)
+ - adding general function to get any primitive (0.0.14)
  - parsing of positional arguments (0.0.13)
  - support for sink pipes (0.0.12)
  - adding standalone build examples (0.0.11)

--- a/examples/plus/README.md
+++ b/examples/plus/README.md
@@ -1,7 +1,11 @@
 # Nu Plugin Plus
 
 There is already an [add](https://github.com/nushell/nushell/blob/master/src/plugins/add.rs) plugin (so we can't define that) but this simple plugin is instead called "plus" and shows how to use a filter with
-positional arguments to add two numbers (integers). Here are simple examples of how it works!
+positional arguments to add two numbers (integers).  You can watch an example here:
+
+[![asciicast](https://asciinema.org/a/277050.svg)](https://asciinema.org/a/277050?speed=2)
+
+Or here are simple examples of how it works!
 
 ```bash
 Add a number to what is passed to the filter.
@@ -36,6 +40,23 @@ If you give the wrong type, no go!
 ```bash
 > echo boo | plus 8
 boo is not a number
+```
+
+Combine with other plugins too. Here is an example of listing files, getting the name,
+calculating the length, and adding 100 to it.
+
+```bash
+> ls | get name | len | plus 100
+━━━┯━━━━━━━━━━━
+ # │ <unknown> 
+───┼───────────
+ 0 │ 114 
+ 1 │ 108 
+ 2 │ 109 
+ 3 │ 109 
+ 4 │ 110 
+ 5 │ 121 
+━━━┷━━━━━━━━━━━
 ```
 
 ## Run Locally

--- a/examples/plus/nu_plugin_plus
+++ b/examples/plus/nu_plugin_plus
@@ -21,11 +21,8 @@ def runFilter(plugin, params):
        plugin.print_int_response()
        plugin.print_string_response()
     '''
-    # This should be a (string) number, but we can't be certain
-    try:
-        value = plugin.get_string_primitive()
-    except:
-        plugin.print_string_response(plugin.get_help())
+    # don't care about type, can also be get_string_primitive or get_int_primitive
+    value = plugin.get_primitive()
 
     # Get the string primitive passed from the filter (should be Int)
     try:

--- a/nushell/filter.py
+++ b/nushell/filter.py
@@ -32,11 +32,14 @@ class FilterPlugin(PluginBase):
     def get_int_primitive(self):
         return self.get_primitive("Int")
 
-    def get_primitive(self, primitive_type):
+    def get_primitive(self, primitive_type=None):
         '''get a primitive from an item, expected to be of a type (String
            or Int typically). We get this from last passed params.
         '''
-        return self.params["item"]["Primitive"][primitive_type]
+        if primitive_type:
+            return self.params["item"]["Primitive"][primitive_type]
+        else:
+            return list(self.params["item"]["Primitive"].values())[0]
 
     def print_primitive_response(self, value, primitive_type):
         '''a base function to print a good response with an updated

--- a/nushell/version.py
+++ b/nushell/version.py
@@ -5,7 +5,7 @@
 # Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
 # with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-__version__ = "0.0.13"
+__version__ = "0.0.14"
 AUTHOR = 'Vanessa Sochat'
 AUTHOR_EMAIL = 'vsochat@stanford.edu'
 NAME = 'nushell'


### PR DESCRIPTION
There is a tiny bug in the current implementation that if you pipe a previous filter into the plus plugin, if it's not the right type it won't work. Instead we can allow for any type, and let the plugin determine how to manage the value. This means that the user can do:

```python
plugin.get_primitive()
plugin.get_string_primitive()
plugin.get_int_primitive()
```
And only the first won't error given a mismatched type.

Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>