### PR TITLE
Adding help for filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Critical items to know are:
 Versions here coincide with releases on pypi.
 
 ## [master](https://github.com/vsoch/nushell-plugin-python)
+ - allowing end-filter to return help response (0.0.15)
  - adding general function to get any primitive (0.0.14)
  - parsing of positional arguments (0.0.13)
  - support for sink pipes (0.0.12)

--- a/examples/len/README.md
+++ b/examples/len/README.md
@@ -61,12 +61,12 @@ the present working directory.
 ```
 
 As a helper, the plugin library automatically adds a `--help` function that also shows
-usage for each argument, if the creator provided it. Since this is a filter,
-you have to run it as a filter (to trigger the filter method) to see it:
+usage for each argument, if the creator provided it.
 
 ```bash
-> echo four | len --help
+> len --help
 len: Return the length of a string
+
 --help              show this usage
 ```
 

--- a/nushell/filter.py
+++ b/nushell/filter.py
@@ -78,8 +78,9 @@ class FilterPlugin(PluginBase):
             self.logger.info("REQUEST %s" % line)
             self.logger.info("METHOD %s" % method)
 
-            # Store raw parameters for the plugin memory
-            self.params = x.get('params', {})
+            # Store raw parameters for the plugin memory, only if not end filter
+            if method != "end_filter":
+                self.params = x.get('params', {})
 
             # Case 1: Nu is asking for the config to discover the plugin
             if method == "config":
@@ -95,21 +96,25 @@ class FilterPlugin(PluginBase):
                 self.logger.info("Begin Filter Args: %s" % self.args)
                 self.print_good_response([])
 
+            # End filter can end the filter, OR call a custom sink function
             elif method == "end_filter":
-                self.print_good_response([])
+
+                # If the user wants help, return the help and break
+                if "help" in self.args:
+
+                    # We need to update so name_tag is tag (not logical I know)
+                    self.params['tag'] = self.params.get('name_tag', self.getTag())
+                    self.logger.info("User requested --help")
+                    self.print_string_response(self.get_help())
+                else:
+                    self.print_good_response([])
                 break
 
             # Run the filter, passing the unparsed params
             elif method == "filter":
-
-                # If the user wants help, return the help and break
-                if "help" in self.args:
-                    self.logger.info("User requested --help")
-                    self.print_string_response(self.get_help())
  
-                else:
-                    self.logger.info("RAW PARAMS: %s" % self.params)
-                    runFilter(self, self.args)
+                self.logger.info("RAW PARAMS: %s" % self.params)
+                runFilter(self, self.args)
 
             else:
                 break

--- a/nushell/version.py
+++ b/nushell/version.py
@@ -5,7 +5,7 @@
 # Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
 # with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-__version__ = "0.0.14"
+__version__ = "0.0.15"
 AUTHOR = 'Vanessa Sochat'
 AUTHOR_EMAIL = 'vsochat@stanford.edu'
 NAME = 'nushell'


### PR DESCRIPTION
Note that when we get a request to begin_filter, we cache the response under self.params, and then update the "tag" to be taken from "name_tag." Technically this is different from filter (where a tag is provided) and the reason is that filter is providing an item/tag from a data item, and not from an action / etc. that is being parsed (name). Simply, the values under "params" are representing different things between begin_filter and filter.

Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>