### PR TITLE
Adding help and connection to circleci for testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,67 @@
+################################################################################
+# Functions
+################################################################################
+
+# Defaults
+
+defaults: &defaults
+  working_directory: /tmp/src
+
+
+# Environment
+
+sourceenv: &sourceenv
+    name: Source environment variables from the BASH_ENV
+    command: source $BASH_ENV 
+
+
+run_linter: &run_linter
+  name: run linter
+  command: |
+     sudo pip3 install --upgrade pylint
+     cd /tmp/src
+     pylint nushell --ignore=nushell/tests
+
+
+test_nushell: &test_nushell
+  name: Test Nushell Plugin Library in Python
+  command: |
+        which python
+        python --version
+        cd /tmp/src
+        sudo python setup.py install
+        pytest nushell/tests/test*.py
+
+
+################################################################################
+# Jobs
+################################################################################
+
+
+version: 2
+jobs:
+
+  test-python-3:
+    <<: *defaults
+    docker:
+      - image: circleci/python:3.6.4
+    steps:
+      - checkout
+      - setup_remote_docker     
+      - run: *run_linter
+      - run: *test_nushell
+
+
+################################################################################
+# Workflows
+################################################################################
+
+
+workflows:
+  version: 2
+  build_deploy:
+    jobs:
+      - test-python-3:
+          filters:
+            branches:
+              ignore: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,11 +14,15 @@ sourceenv: &sourceenv
     name: Source environment variables from the BASH_ENV
     command: source $BASH_ENV 
 
+install: &install
+  name: install dependencies
+  command: |
+     sudo pip3 install --upgrade pylint pytest
+
 
 run_linter: &run_linter
   name: run linter
   command: |
-     sudo pip3 install --upgrade pylint
      cd /tmp/src
      pylint nushell --ignore=nushell/tests
 
@@ -48,6 +52,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker     
+      - run: *install
       - run: *run_linter
       - run: *test_nushell
 

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,504 @@
+[MASTER]
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code.
+extension-pkg-whitelist=
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=CVS
+
+# Add files or directories matching the regex patterns to the blacklist. The
+# regex matches against base names, not paths.
+ignore-patterns=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
+# number of processors available to use.
+jobs=0
+
+# Control the amount of potential inferred values when inferring a single
+# object. This can help the performance when dealing with large functions or
+# complex, nested conditions.
+limit-inference-results=100
+
+# List of plugins (as comma separated values of python modules names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# Specify a configuration file.
+#rcfile=
+
+# When enabled, pylint would attempt to guess common misconfiguration and emit
+# user-friendly hints instead of false-positive error messages.
+suggestion-mode=yes
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED.
+confidence=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once). You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use "--disable=all --enable=classes
+# --disable=W".
+disable=attribute-defined-outside-init,
+        bad-continuation,
+        bare-except,
+        duplicate-code,
+        fixme,
+        invalid-name,
+        line-too-long,
+        missing-docstring,
+        no-member,
+        protected-access,
+        R,
+        trailing-whitespace,
+        unused-argument,
+        wrong-import-order
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+enable=
+
+
+[REPORTS]
+
+# Python expression which should return a note less than 10 (10 is the highest
+# note). You have access to the variables errors warning, statement which
+# respectively contain the number of errors / warnings messages and the total
+# number of statements analyzed. This is used by the global evaluation report
+# (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details.
+#msg-template=
+
+# Set the output format. Available formats are text, parseable, colorized, json
+# and msvs (visual studio). You can also give a reporter class, e.g.
+# mypackage.mymodule.MyReporterClass.
+output-format=text
+
+# Tells whether to display a full report or only the messages.
+reports=no
+
+# Activate the evaluation score.
+score=yes
+
+
+[REFACTORING]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+# Complete name of functions that never returns. When checking for
+# inconsistent-return-statements if a never returning function is called then
+# it will be considered as an explicit return statement and no message will be
+# printed.
+never-returning-functions=sys.exit
+
+
+[BASIC]
+
+# Naming style matching correct argument names.
+argument-naming-style=snake_case
+
+# Regular expression matching correct argument names. Overrides argument-
+# naming-style.
+#argument-rgx=
+
+# Naming style matching correct attribute names.
+attr-naming-style=snake_case
+
+# Regular expression matching correct attribute names. Overrides attr-naming-
+# style.
+#attr-rgx=
+
+# Bad variable names which should always be refused, separated by a comma.
+bad-names=foo,
+          baz,
+          toto,
+          tutu,
+          tata
+
+# Naming style matching correct class attribute names.
+class-attribute-naming-style=any
+
+# Regular expression matching correct class attribute names. Overrides class-
+# attribute-naming-style.
+#class-attribute-rgx=
+
+# Naming style matching correct class names.
+class-naming-style=PascalCase
+
+# Regular expression matching correct class names. Overrides class-naming-
+# style.
+#class-rgx=
+
+# Naming style matching correct constant names.
+const-naming-style=UPPER_CASE
+
+# Regular expression matching correct constant names. Overrides const-naming-
+# style.
+#const-rgx=
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming style matching correct function names.
+function-naming-style=snake_case
+
+# Regular expression matching correct function names. Overrides function-
+# naming-style.
+#function-rgx=
+
+# Good variable names which should always be accepted, separated by a comma.
+good-names=i,
+           j,
+           k,
+           ex,
+           Run,
+           _
+
+# Include a hint for the correct naming format with invalid-name.
+include-naming-hint=no
+
+# Naming style matching correct inline iteration names.
+inlinevar-naming-style=any
+
+# Regular expression matching correct inline iteration names. Overrides
+# inlinevar-naming-style.
+#inlinevar-rgx=
+
+# Naming style matching correct method names.
+method-naming-style=snake_case
+
+# Regular expression matching correct method names. Overrides method-naming-
+# style.
+#method-rgx=
+
+# Naming style matching correct module names.
+module-naming-style=snake_case
+
+# Regular expression matching correct module names. Overrides module-naming-
+# style.
+#module-rgx=
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+# These decorators are taken in consideration only for invalid-name.
+property-classes=abc.abstractproperty
+
+# Naming style matching correct variable names.
+variable-naming-style=snake_case
+
+# Regular expression matching correct variable names. Overrides variable-
+# naming-style.
+#variable-rgx=
+
+
+[STRING]
+
+# This flag controls whether the implicit-str-concat-in-sequence should
+# generate a warning on implicit string concatenation in sequences defined over
+# several lines.
+check-str-concat-over-line-jumps=no
+
+
+[SPELLING]
+
+# Limits count of emitted suggestions for spelling mistakes.
+max-spelling-suggestions=4
+
+# Spelling dictionary name. Available dictionaries: none. To make it working
+# install python-enchant package..
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to indicated private dictionary in
+# --spelling-private-dict-file option instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,
+      XXX,
+      TODO
+
+
+[SIMILARITIES]
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+
+[LOGGING]
+
+# Format style used to check logging format string. `old` means using %
+# formatting, while `new` is for `{}` formatting.
+logging-format-style=old
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format.
+logging-modules=logging
+
+
+[VARIABLES]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid defining new builtins when possible.
+additional-builtins=
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,
+          _cb
+
+# A regular expression matching the name of dummy variables (i.e. expected to
+# not be used).
+dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore.
+ignored-argument-names=_.*|^ignored_|^unused_
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,past.builtins,future.builtins,builtins,io
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# Tells whether to warn about missing members when the owner of the attribute
+# is inferred to be None.
+ignore-none=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis. It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The minimum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+
+[FORMAT]
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Number of spaces of indent required inside a hanging or continued line.
+indent-after-paren=4
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Maximum number of characters on a single line.
+max-line-length=100
+
+# Maximum number of lines in a module.
+max-module-lines=1000
+
+# List of optional constructs for which whitespace checking is disabled. `dict-
+# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
+# `trailing-comma` allows a space between comma and closing bracket: (a, ).
+# `empty-line` allows space-only lines.
+no-space-check=trailing-comma,
+               dict-separator
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method.
+max-args=5
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Maximum number of boolean expressions in an if statement.
+max-bool-expr=5
+
+# Maximum number of branch for function / method body.
+max-branches=12
+
+# Maximum number of locals for function / method body.
+max-locals=15
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of return / yield for function / method body.
+max-returns=6
+
+# Maximum number of statements in function / method body.
+max-statements=50
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+
+[IMPORTS]
+
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+# Deprecated modules which should not be used, separated by a comma.
+deprecated-modules=optparse,tkinter.tix
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled).
+ext-import-graph=
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled).
+import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled).
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,
+                      __new__,
+                      setUp
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,
+                  _fields,
+                  _replace,
+                  _source,
+                  _make
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=cls
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "BaseException, Exception".
+overgeneral-exceptions=BaseException,
+                       Exception

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Critical items to know are:
 Versions here coincide with releases on pypi.
 
 ## [master](https://github.com/vsoch/nushell-plugin-python)
+ - basic testing (0.0.16)
  - allowing end-filter to return help response (0.0.15)
  - adding general function to get any primitive (0.0.14)
  - parsing of positional arguments (0.0.13)

--- a/nushell/tests/helpers.py
+++ b/nushell/tests/helpers.py
@@ -1,0 +1,65 @@
+#!/usr/bin/python
+
+# Copyright (C) 2019-2020 Vanessa Sochat.
+
+# This Source Code Form is subject to the terms of the
+# Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
+# with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+def assert_good_response(response):
+    '''ensure that a response is good, meaning jsonrpc 2.0 and method response
+    '''
+    for key in ['jsonrpc', 'method', 'params']:
+        assert key in response
+
+    assert isinstance(response['params'], (dict, list))
+    assert response['method'] == 'response'
+
+
+def check_plugin_config(plugin, plugin_name, usage, is_filter):
+    '''a helper function to test a general plugin configuration
+    '''
+ 
+    # Before adding args or getting help, we don't have any parameters
+    assert not plugin.argUsage
+    assert not plugin.positional
+    assert not plugin._positional
+    assert not plugin.named
+
+    # Help shouldn't be in current help
+    assert "--help" not in plugin.get_help()
+
+    # Once we generate a config (like the first call) we should have help
+    plugin_config = plugin.get_config()
+    assert "help" in plugin.named
+
+    for key in ['name', 'usage', 'positional', 'rest_positional', 'named', 'is_filter']:
+        assert key in plugin_config
+
+    assert plugin_config["is_filter"] == is_filter
+    assert plugin_config["usage"] == usage
+    assert plugin_config["name"] == plugin_name
+    assert plugin.name == plugin_name
+    assert plugin.usage == usage
+
+    # The name and usage should be included, and now --help is added too
+    for contender in [usage, plugin_name, '--help', 'show this usage']:
+        assert contender in plugin.get_help()
+
+def check_remove_help(plugin, plugin_name, usage, is_filter):
+    '''similar checks, but remove the help parameters
+    '''
+    # But if we requested to not add help, shouldn't be there
+    plugin_config = plugin.get_config()
+    assert "help" not in plugin.named
+    assert "--help" not in plugin.get_help()
+
+    # Now add named arguments
+    plugin.add_named_argument("greet", "Switch", usage="say hello")
+    assert "greet" in plugin.argUsage
+    assert "greet" in plugin.named
+
+    # The user can optionally just give a name (a positional argument)
+    plugin.add_positional_argument("avatar", "Optional", "String")
+    assert "avatar" in plugin._positional
+    assert plugin.positional # len > 0

--- a/nushell/tests/plugin_requests.py
+++ b/nushell/tests/plugin_requests.py
@@ -1,0 +1,184 @@
+#!/usr/bin/python
+
+# Copyright (C) 2019-2020 Vanessa Sochat.
+
+# This Source Code Form is subject to the terms of the
+# Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
+# with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# A config request (for sink or filter)
+config_request = {"jsonrpc":"2.0", "method":"config", "params":[]}
+
+
+## Sinks
+
+# A basic sink without positional arguments
+sink_named_request = {
+   "jsonrpc":"2.0",
+   "method":"sink",
+   "params":[
+      {
+         "args":{
+            "positional": None,
+            "named":{
+               "sink":{
+                  "tag":{
+                     "anchor": None,
+                     "span":{
+                        "start":10,
+                        "end":14
+                     }
+                  },
+                  "item":{
+                     "Primitive":{
+                        "Boolean": True
+                     }
+                  }
+               }
+            }
+         },
+         "name_tag":{
+            "anchor": None,
+            "span":{
+               "start":0,
+               "end":7
+            }
+         }
+      },
+      [] # empty pipe
+   ]
+}
+
+# A help request changes the sink flag to help
+sink_help_request = {
+   "jsonrpc":"2.0",
+   "method":"sink",
+   "params":[
+      {
+         "args":{
+            "positional": None,
+            "named":{
+               "help":{
+                  "tag":{
+                     "anchor": None,
+                     "span":{
+                        "start":10,
+                        "end":14
+                     }
+                  },
+                  "item":{
+                     "Primitive":{
+                        "Boolean": True
+                     }
+                  }
+               }
+            }
+         },
+         "name_tag":{
+            "anchor": None,
+            "span":{
+               "start":0,
+               "end":7
+            }
+         }
+      },
+      [] # empty pipe
+   ]
+}
+
+
+## Filters
+
+# We should save params at begin request
+filter_begin_request = {
+   "jsonrpc":"2.0",
+   "method":"begin_filter",
+   "params":{
+      "args":{
+         "positional": None,
+         "named":{
+            "help":{
+               "tag":{
+                  "anchor": None,
+                  "span":{
+                     "start":6,
+                     "end":10
+                  }
+               },
+               "item":{
+                  "Primitive":{
+                     "Boolean":True
+                  }
+               }
+            }
+         }
+      },
+      "name_tag":{
+         "anchor":None,
+         "span":{
+            "start":0,
+            "end":3
+         }
+      }
+   }
+}
+
+filter_end_request = {"jsonrpc":"2.0", "method":"end_filter", "params":[]}
+
+filter_string_request = {
+   "jsonrpc":"2.0",
+   "method":"filter",
+   "params":{
+      "tag":{
+         "anchor": None,
+         "span":{
+            "start":0,
+            "end":2
+         }
+      },
+      "item":{
+         "Primitive":{
+            "String":"pancakes"
+         }
+      }
+   }
+}
+
+filter_int_request = {
+   "jsonrpc":"2.0",
+   "method":"filter",
+   "params":{
+      "tag":{
+         "anchor": None,
+         "span":{
+            "start":0,
+            "end":2
+         }
+      },
+      "item":{
+         "Primitive":{
+            "Int":"imanumber"
+         }
+      }
+   }
+}
+
+# A custom primitive
+filter_custom_request = {
+   "jsonrpc":"2.0",
+   "method":"filter",
+   "params":{
+      "tag":{
+         "anchor": None,
+         "span":{
+            "start":0,
+            "end":2
+         }
+      },
+      "item":{
+         "Primitive":{
+            "Any":"imathing"
+         }
+      }
+   }
+}

--- a/nushell/tests/test_filter.py
+++ b/nushell/tests/test_filter.py
@@ -1,0 +1,95 @@
+#!/usr/bin/python
+
+# Copyright (C) 2019-2020 Vanessa Sochat.
+
+# This Source Code Form is subject to the terms of the
+# Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
+# with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from nushell.filter import FilterPlugin
+from .helpers import (
+    assert_good_response,
+    check_plugin_config,
+    check_remove_help
+)
+from .plugin_requests import (
+    config_request,
+    filter_begin_request,
+    filter_end_request,
+    filter_string_request,
+    filter_int_request,
+    filter_custom_request
+)
+
+import os
+import pytest
+
+
+def func(plugin, params):
+    '''func will be executed by the calling FilterPlugin when method is "filter"
+       instead of printing responses, we return them to the caller for testing
+    '''
+    return params
+
+
+def test_filter_plugin(tmp_path):
+    '''test creation of a simple sink plugin
+    '''
+    plugin_name = "filter"
+    usage = "A dummy filter plugin to print to the terminal"
+    plugin = FilterPlugin(name=plugin_name, usage=usage, logging=False)
+
+    # Before config, we haven't cached any params
+    for attr in ['params', 'args']:
+        assert not getattr(plugin, attr, None)
+
+    # Test request for config
+    response = plugin.test(func, config_request)
+    assert_good_response(response)
+    assert plugin.get_config() == response['params']['Ok']
+
+    # After config, we have empty params / args
+    for attr in ['params', 'args']:
+        assert getattr(plugin, attr) in [[], {}]
+
+    # Check begin_filter
+    response = plugin.test(func, filter_begin_request)
+    assert_good_response(response)
+    assert response['params'] == {'Ok': []}
+
+    # Now params should be populated
+    assert 'args' in plugin.params
+    assert 'help' in plugin.args and '_positional' in plugin.args
+
+    # Testing the filter method with string request
+    response = plugin.test(func, filter_string_request)
+    assert plugin.get_string_primitive() == 'pancakes'
+
+    # Filters differ from sinks in tha they don't return _pipe
+    for key in ['help', '_positional']:
+        assert key in response
+
+    # Testing the filter method with int request
+    response = plugin.test(func, filter_int_request)
+    assert plugin.get_int_primitive() == 'imanumber'
+
+    # Testing the filter method with custom request
+    response = plugin.test(func, filter_custom_request)
+    assert plugin.get_primitive("Any") == 'imathing'
+
+    # Test end_filter request     
+    response = plugin.test(func, filter_end_request)
+ 
+
+
+def test_filter_config(tmp_path):
+    '''test configure of a simple sink plugin
+    '''
+    plugin_name = "filter"
+    usage = "A dummy filter plugin to print to the terminal"
+    plugin = FilterPlugin(name=plugin_name, usage=usage, logging=False)
+    check_plugin_config(plugin, plugin_name, usage, is_filter=True)
+
+    # Test without adding help
+    plugin = FilterPlugin(name=plugin_name, usage=usage, logging=False, add_help=False)
+    check_remove_help(plugin, plugin_name, usage, is_filter=True)

--- a/nushell/tests/test_sink.py
+++ b/nushell/tests/test_sink.py
@@ -1,0 +1,77 @@
+#!/usr/bin/python
+
+# Copyright (C) 2019-2020 Vanessa Sochat.
+
+# This Source Code Form is subject to the terms of the
+# Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
+# with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from nushell.sink import SinkPlugin
+from .helpers import (
+    assert_good_response,
+    check_plugin_config,
+    check_remove_help
+)
+from .plugin_requests import (
+    config_request,
+    sink_named_request,
+    sink_help_request
+)
+
+import os
+import pytest
+
+
+def sink(plugin, params):
+    '''sink will be executed by the calling SinkPlugin when method is "sink"
+       instead of just printing, we return params to test
+    '''
+    return params
+
+
+def test_sink_name(tmp_path):
+    '''ensure that a plugin's name is made all lowercase, with spaces removed
+       note that the user is allowed to use special characters.
+    '''
+    # Name must be made all lowercase
+    plugin_name = "sink"
+    usage = "A dummy sink plugin to print to the terminal"
+    plugin = SinkPlugin(name=plugin_name, usage=usage, logging=False)
+
+    assert plugin._clean_name("a a a") == "a-a-a"
+    assert plugin._clean_name("SINK") == "sink"
+
+def test_sink_plugin(tmp_path):
+    '''test creation of a simple sink plugin
+    '''
+    plugin_name = "sink"
+    usage = "A dummy sink plugin to print to the terminal"
+    plugin = SinkPlugin(name=plugin_name, usage=usage, logging=False)
+
+    # Test request for config
+    response = plugin.test(sink, config_request)
+    assert_good_response(response)
+    assert plugin.get_config() == response['params']['Ok']
+
+    # Test help request (should return help)
+    response = plugin.test(sink, sink_help_request)
+    assert plugin.name in response and plugin.usage in response
+ 
+    # Test "sink" named arg request (should return params from sink())
+    # {'sink': True, '_positional': [], '_pipe': []}
+    response = plugin.test(sink, sink_named_request)
+    for key in ['sink', '_positional', "_pipe"]:
+        assert key in response
+
+    
+def test_sink_config(tmp_path):
+    '''test configure of a simple sink plugin
+    '''
+    plugin_name = "sink"
+    usage = "A dummy sink plugin to print to the terminal"
+    plugin = SinkPlugin(name=plugin_name, usage=usage, logging=False)
+    check_plugin_config(plugin, plugin_name, usage, is_filter=False)
+
+    # Test without adding help
+    plugin = SinkPlugin(name=plugin_name, usage=usage, logging=False, add_help=False)
+    check_remove_help(plugin, plugin_name, usage, is_filter=False)

--- a/nushell/version.py
+++ b/nushell/version.py
@@ -5,7 +5,7 @@
 # Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
 # with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-__version__ = "0.0.15"
+__version__ = "0.0.16"
 AUTHOR = 'Vanessa Sochat'
 AUTHOR_EMAIL = 'vsochat@stanford.edu'
 NAME = 'nushell'
@@ -15,4 +15,8 @@ DESCRIPTION = "Python module to easily create nushell plugins"
 LICENSE = "LICENSE"
 
 INSTALL_REQUIRES = (
+)
+
+TESTS_REQUIRES = (
+    ('pytest', {'min_version': '4.6.2'}),
 )

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ def get_lookup():
         exec(filey.read(), lookup)
     return lookup
 
-def get_requirements(lookup=None):
+def get_requirements(lookup=None, key="INSTALL_REQUIRES"):
     '''get_requirements reads in requirements and versions from
        the lookup obtained with get_lookup'''
 
@@ -32,7 +32,7 @@ def get_requirements(lookup=None):
         lookup = get_lookup()
 
     install_requires = []
-    for module in lookup['INSTALL_REQUIRES']:
+    for module in lookup[key]:
         module_name = module[0]
         module_meta = module[1]
         if "exact_version" in module_meta:
@@ -72,7 +72,7 @@ with open('README.md') as readme:
 if __name__ == "__main__":
 
     INSTALL_REQUIRES = get_requirements(lookup)
-    TESTS_REQUIRES = get_requirements(lookup)
+    TESTS_REQUIRES = get_requirements(lookup, "TESTS_REQUIRES")
 
     setup(name=NAME,
           version=VERSION,


### PR DESCRIPTION
This pull request will add the first basic set of tests for nushell plugin (sink and filter) generation using the Python library here. We also add integration with CircleCI to run the tests, and pylint for the code. To allow for the testing, I've added a "test" function to each plugin class that performs the same functions, but instead of printing a response, returns to the caller.

Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>